### PR TITLE
DOJ-128: CORS config for local/dev/stage.

### DIFF
--- a/docroot/sites/default/default.services.yml
+++ b/docroot/sites/default/default.services.yml
@@ -165,7 +165,7 @@ parameters:
     # Specify allowed request methods, specify ['*'] to allow all possible ones.
     allowedMethods: []
     # Configure requests allowed from specific origins.
-    allowedOrigins: ['http://localhost:4000']
+    allowedOrigins: ['*']
     # Sets the Access-Control-Expose-Headers header.
     exposedHeaders: false
     # Sets the Access-Control-Max-Age header.

--- a/docroot/sites/default/default.services.yml
+++ b/docroot/sites/default/default.services.yml
@@ -159,13 +159,13 @@ parameters:
    # for more information about the topic in general.
    # Note: By default the configuration is disabled.
   cors.config:
-    enabled: false
+    enabled: true
     # Specify allowed headers, like 'x-allowed-header'.
     allowedHeaders: []
     # Specify allowed request methods, specify ['*'] to allow all possible ones.
     allowedMethods: []
     # Configure requests allowed from specific origins.
-    allowedOrigins: ['*']
+    allowedOrigins: ['http://localhost:4000']
     # Sets the Access-Control-Expose-Headers header.
     exposedHeaders: false
     # Sets the Access-Control-Max-Age header.

--- a/docroot/sites/default/services.yml
+++ b/docroot/sites/default/services.yml
@@ -165,7 +165,7 @@ parameters:
     # Specify allowed request methods, specify ['*'] to allow all possible ones.
     allowedMethods: []
     # Configure requests allowed from specific origins.
-    allowedOrigins: ['http://localhost:4000']
+    allowedOrigins: ['*']
     # Sets the Access-Control-Expose-Headers header.
     exposedHeaders: false
     # Sets the Access-Control-Max-Age header.

--- a/docroot/sites/default/services.yml
+++ b/docroot/sites/default/services.yml
@@ -159,13 +159,13 @@ parameters:
    # for more information about the topic in general.
    # Note: By default the configuration is disabled.
   cors.config:
-    enabled: false
+    enabled: true
     # Specify allowed headers, like 'x-allowed-header'.
     allowedHeaders: []
     # Specify allowed request methods, specify ['*'] to allow all possible ones.
     allowedMethods: []
     # Configure requests allowed from specific origins.
-    allowedOrigins: ['*']
+    allowedOrigins: ['http://localhost:4000']
     # Sets the Access-Control-Expose-Headers header.
     exposedHeaders: false
     # Sets the Access-Control-Max-Age header.


### PR DESCRIPTION
This adds `http://localhost:4000` as an acceptable origin for API requests. This should only be enabled for local/dev/staging, so let me know if there is a better config to add this.

Prod will have a config for `www.foia.gov` or `beta.foia.gov`, but I'm not sure where to put that yet.