### PR TITLE
DOJ-111: Add X-Api-Key header for CORS.

### DIFF
--- a/docroot/sites/default/services.yml
+++ b/docroot/sites/default/services.yml
@@ -161,7 +161,9 @@ parameters:
   cors.config:
     enabled: true
     # Specify allowed headers, like 'x-allowed-header'.
-    allowedHeaders: ['Content-Type']
+    # X-Api-Key is needed for api.data.gov work-around
+    # https://github.com/NREL/api-umbrella/issues/391
+    allowedHeaders: ['Content-Type', 'X-Api-Key']
     # Specify allowed request methods, specify ['*'] to allow all possible ones.
     allowedMethods: ['GET', 'POST']
     # Configure requests allowed from specific origins.


### PR DESCRIPTION
api.data.gov has a bug where the pre-flight CORS request is denied (403
Forbidden), so the work around is to pass it through to the back end and have
the back end return the proper Access-Control headers.

https://github.com/NREL/api-umbrella/issues/391