### PR TITLE
DOJ-485: New virus scan status field causing KernelTests to fail

### DIFF
--- a/docroot/modules/custom/foia_webform/src/FoiaSubmissionServiceApi.php
+++ b/docroot/modules/custom/foia_webform/src/FoiaSubmissionServiceApi.php
@@ -420,16 +420,21 @@ class FoiaSubmissionServiceApi implements FoiaSubmissionServiceInterface {
     $fileContents = [];
     if (!empty($files)) {
       foreach ($files as $fid) {
-        $currentFile = File::load($fid);
-        $virusScanStatus = $currentFile->get('field_virus_scan_status')->getString();
-        if ($virusScanStatus === 'virus') {
-          $fileContents[] = [
-            'content_type' => $currentFile->getMimeType(),
-            'filedata' => NULL,
-            'filename' => $currentFile->getFilename(),
-            'filesize' => (int) $currentFile->getSize(),
-            'filestatus' => t('File removed by virus scanning.'),
-          ];
+        if (is_int($fid)) {
+          $currentFile = File::load($fid);
+          $virusScanStatus = $currentFile->get('field_virus_scan_status')->getString();
+          if ($virusScanStatus === 'virus') {
+            $fileContents[] = [
+              'content_type' => $currentFile->getMimeType(),
+              'filedata' => NULL,
+              'filename' => $currentFile->getFilename(),
+              'filesize' => (int) $currentFile->getSize(),
+              'filestatus' => t('File removed by virus scanning.'),
+            ];
+          }
+        }
+        else {
+          $fileContents[] = $fid;
         }
       }
     }

--- a/docroot/modules/custom/foia_webform/tests/src/Kernel/FoiaSubmissionServiceApiTest.php
+++ b/docroot/modules/custom/foia_webform/tests/src/Kernel/FoiaSubmissionServiceApiTest.php
@@ -254,8 +254,6 @@ class FoiaSubmissionServiceApiTest extends KernelTestBase {
 
   /**
    * Tests the assembly of request data with attachments.
-   *
-   * @group broken
    */
   public function testAssesmbleRequestDataWithAttachments() {
     $configPath = '/var/www/dojfoia/config/default';
@@ -336,6 +334,14 @@ class FoiaSubmissionServiceApiTest extends KernelTestBase {
           'filedata' => base64_encode(file_get_contents($file->getFileUri())),
           'filename' => $file->getFilename(),
           'filesize' => $file->getSize(),
+        ],
+      ],
+      'removed_files' => [
+        [
+          'content_type' => 'text/plain',
+          'filedata' => 'dGVzdA==',
+          'filename' => 'test.txt',
+          'filesize' => 4,
         ],
       ],
     ];


### PR DESCRIPTION
Failures seen when running php-unit on latest develop branch.

```
OK (1 test, 7 assertions)
[Testing\PHPUnit] Done in 7.856s
[Testing\PHPUnit] Running PHPUnit  --log-junit /var/www/dojfoia/reports/phpunit/results.xml . -v --configuration /var/www/dojfoia/tests/phpunit/phpunit.xml
[Testing\PHPUnit] Running /var/www/dojfoia/vendor/bin/phpunit --log-junit /var/www/dojfoia/reports/phpunit/results.xml . -v --configuration /var/www/dojfoia/tests/phpunit/phpunit.xml in /var/www/dojfoia/docroot/modules/custom/foia_webform
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Runtime:	PHP 5.6.32-1+ubuntu14.04.1+deb.sury.org+2 with Xdebug 2.5.0
Configuration:	/var/www/dojfoia/tests/phpunit/phpunit.xml

............E....E.

Time: 1.13 minutes, Memory: 9.25MB

There were 2 errors:

1) Drupal\Tests\foia_webform\Kernel\FoiaSubmissionQueueWorkerTest::testAssesmbleRequestDataWithAttachments
InvalidArgumentException: Field field_virus_scan_status is unknown.

/var/www/dojfoia/docroot/core/lib/Drupal/Core/Entity/ContentEntityBase.php:509
/var/www/dojfoia/docroot/core/lib/Drupal/Core/Entity/ContentEntityBase.php:490
/var/www/dojfoia/docroot/modules/custom/foia_webform/src/FoiaSubmissionServiceApi.php:395
/var/www/dojfoia/docroot/modules/custom/foia_webform/src/FoiaSubmissionServiceApi.php:332
/var/www/dojfoia/docroot/modules/custom/foia_webform/src/FoiaSubmissionServiceApi.php:147
/var/www/dojfoia/docroot/modules/custom/foia_webform/src/FoiaSubmissionServiceApi.php:118
/var/www/dojfoia/docroot/modules/custom/foia_webform/tests/src/Kernel/ReflectionTrait.php:30
/var/www/dojfoia/docroot/modules/custom/foia_webform/tests/src/Kernel/FoiaSubmissionServiceApiTest.php:340

2) Drupal\Tests\foia_webform\Kernel\FoiaSubmissionServiceApiTest::testAssesmbleRequestDataWithAttachments
InvalidArgumentException: Field field_virus_scan_status is unknown.

/var/www/dojfoia/docroot/core/lib/Drupal/Core/Entity/ContentEntityBase.php:509
/var/www/dojfoia/docroot/core/lib/Drupal/Core/Entity/ContentEntityBase.php:490
/var/www/dojfoia/docroot/modules/custom/foia_webform/src/FoiaSubmissionServiceApi.php:395
/var/www/dojfoia/docroot/modules/custom/foia_webform/src/FoiaSubmissionServiceApi.php:332
/var/www/dojfoia/docroot/modules/custom/foia_webform/src/FoiaSubmissionServiceApi.php:147
/var/www/dojfoia/docroot/modules/custom/foia_webform/src/FoiaSubmissionServiceApi.php:118
/var/www/dojfoia/docroot/modules/custom/foia_webform/tests/src/Kernel/ReflectionTrait.php:30
/var/www/dojfoia/docroot/modules/custom/foia_webform/tests/src/Kernel/FoiaSubmissionServiceApiTest.php:340

FAILURES!
Tests: 19, Assertions: 191, Errors: 2.
[Testing\PHPUnit]  Exit code 2  Time 01:07
[error]  PHPUnit tests failed.
[error]  Command `tests:phpunit ` exited with code 1.
Connection to 127.0.0.1 closed.
```