### PR TITLE
Doj vm setup

### DIFF
--- a/blt/project.yml
+++ b/blt/project.yml
@@ -6,7 +6,7 @@ project:
     name: lightning
   local:
     protocol: http
-    hostname: 'local.${project.machine_name}.gov'
+    hostname: 'local-api.foia.doj.gov'
 git:
   default_branch: foia-develop
   remotes:

--- a/box/config.yml
+++ b/box/config.yml
@@ -1,5 +1,5 @@
 # Update the hostname to the local development environment hostname.
-vagrant_hostname: local.dojfoia.gov
+vagrant_hostname: local-api.foia.doj.gov
 vagrant_machine_name: dojfoia
 
 # Set the IP address so it doesn't conflict with other Drupal VM instances.

--- a/box/doj/README.md
+++ b/box/doj/README.md
@@ -1,0 +1,10 @@
+# DOJ-specific Development Box
+
+Internal DOJ developers are not able to run BLT, so will need a different setup
+for local development. Local installation will consist of these steps:
+
+* Copy the `config.yml` file in this folder into the /box folder and rename it
+  `local.config.yml`, eg: `mv box/doj/config.yml box/local.config.yml`.
+* Ensure unrestricted internet access (no proxy) and run `vagrant up`.
+* Run `vagrant ssh` to get into the VM.
+* Run `bash /vagrant/box/doj/vm-setup.sh`.

--- a/box/doj/README.md
+++ b/box/doj/README.md
@@ -3,7 +3,13 @@
 Internal DOJ developers are not able to run BLT, so will need a different setup
 for local development. Local installation will consist of these steps:
 
-* Copy the `local.config.yml` file in this folder into the /box folder.
-* Ensure unrestricted internet access (no proxy) and run `vagrant up`.
-* Run `vagrant ssh` to get into the VM.
-* Run `bash /vagrant/box/doj/vm-setup.sh`.
+1. Clone the foia-api repository in Windows.
+2. Manually create a `vendor` folder, and a `geerlingguy` folder, such as:
+   `/path/to/repo/vendor/geerlingguy`
+3. Go into the `geerlingguy` folder and clone DrupalVM:
+   `git clone https://github.com/geerlingguy/drupal-vm.git`
+4. Copy the `local.config.yml` file in this folder into the /box folder:
+   `cp /path/to/repo/box/doj/local.config.yml /path/to/repo/box/local.config.yml`
+5. Ensure unrestricted internet access (no proxy) and run `vagrant up`.
+6. Run `vagrant ssh` to get into the VM.
+7. Run `bash /vagrant/box/doj/vm-setup.sh`.

--- a/box/doj/README.md
+++ b/box/doj/README.md
@@ -3,13 +3,17 @@
 Internal DOJ developers are not able to run BLT, so will need a different setup
 for local development. Local installation will consist of these steps:
 
-1. Clone the foia-api repository in Windows.
-2. Manually create a `vendor` folder, and a `geerlingguy` folder, such as:
-   `/path/to/repo/vendor/geerlingguy`
+1. Clone the foia-api repository in Windows:
+   `git clone https://github.com/usdoj/foia-api.git`
+2. Manually create a `vendor` folder, and a `geerlingguy` folder:
+   `mkdir -p /path/to/repo/vendor/geerlingguy`
 3. Go into the `geerlingguy` folder and clone DrupalVM:
    `git clone https://github.com/geerlingguy/drupal-vm.git`
 4. Copy the `local.config.yml` file in this folder into the /box folder:
    `cp /path/to/repo/box/doj/local.config.yml /path/to/repo/box/local.config.yml`
-5. Ensure unrestricted internet access (no proxy) and run `vagrant up`.
-6. Run `vagrant ssh` to get into the VM.
-7. Run `bash /vagrant/box/doj/vm-setup.sh`.
+5. Ensure unrestricted internet access (no proxy) and run:
+   `vagrant up`
+6. SSH into the VM:
+   `vagrant ssh`
+7. Run the Bash script to complete the setup, inside the VM:
+   `bash /vagrant/box/doj/vm-setup.sh`

--- a/box/doj/README.md
+++ b/box/doj/README.md
@@ -3,8 +3,7 @@
 Internal DOJ developers are not able to run BLT, so will need a different setup
 for local development. Local installation will consist of these steps:
 
-* Copy the `config.yml` file in this folder into the /box folder and rename it
-  `local.config.yml`, eg: `mv box/doj/config.yml box/local.config.yml`.
+* Copy the `local.config.yml` file in this folder into the /box folder.
 * Ensure unrestricted internet access (no proxy) and run `vagrant up`.
 * Run `vagrant ssh` to get into the VM.
 * Run `bash /vagrant/box/doj/vm-setup.sh`.

--- a/box/doj/local.config.yml
+++ b/box/doj/local.config.yml
@@ -1,0 +1,36 @@
+# DrupalVM configuration for a VirtualBox containing both the "front stage" and
+# the "back stage" for www.foia.gov, tailored for local DOJ development.
+
+# Update the hostname to the local development environment hostname. This host
+# tweaked because we need it locally to end with "doj.gov".
+vagrant_hostname: local-api.foia.doj.gov
+
+# Set the IP address so it doesn't conflict with other Drupal VM instances. This
+# tweaked because we need it to end with 33.x.
+vagrant_ip: 192.168.33.83
+
+# Use only inside-VM workflow - no synced folders, because of restrictive DOJ
+# networks/laptops.
+vagrant_synced_folders: []
+vagrant_synced_folder_default_type: ""
+
+# Apache VirtualHosts - just one each for the front/back stages, plus Adminer.
+apache_vhosts:
+  - servername: "{{ drupal_domain }}"
+    serveralias: "local.dojfoia.gov"
+    documentroot: "{{ drupal_core_path }}"
+    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
+
+  - servername: "local-www.foia.doj.gov"
+    documentroot: "/var/www/foia.gov/_site"
+    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
+
+  - servername: "adminer.{{ vagrant_hostname }}"
+    documentroot: "{{ adminer_install_dir }}"
+    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
+
+# The front stage requires node 6.x.
+nodejs_version: "6.x"
+
+# We're doing all post-provisioning manually because of restrictive laptops.
+post_provision_scripts: []

--- a/box/doj/local.config.yml
+++ b/box/doj/local.config.yml
@@ -1,12 +1,7 @@
 # DrupalVM configuration for a VirtualBox containing both the "front stage" and
 # the "back stage" for www.foia.gov, tailored for local DOJ development.
 
-# Update the hostname to the local development environment hostname. This host
-# tweaked because we need it locally to end with "doj.gov".
-vagrant_hostname: local-api.foia.doj.gov
-
-# Set the IP address so it doesn't conflict with other Drupal VM instances. This
-# tweaked because we need it to end with 33.x.
+# This IP is tweaked because we need it to end with 33.x.
 vagrant_ip: 192.168.33.83
 
 # Use only inside-VM workflow - no synced folders, because of restrictive DOJ
@@ -17,7 +12,6 @@ vagrant_synced_folder_default_type: ""
 # Apache VirtualHosts - just one each for the front/back stages, plus Adminer.
 apache_vhosts:
   - servername: "{{ drupal_domain }}"
-    serveralias: "local.dojfoia.gov"
     documentroot: "{{ drupal_core_path }}"
     extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
 

--- a/box/doj/vm-setup.sh
+++ b/box/doj/vm-setup.sh
@@ -17,6 +17,9 @@ if [ ! -e "$DRUPAL_BASIC_SETUP_FILE" ]; then
   # Back-stage installation.
   cd /var/www/dojfoia
   composer install
+  cp docroot/sites/default/settings/default.local.settings.php docroot/sites/default/settings/local.settings.php
+  cp -r simplesamlphp/* vendor/simplesamlphp/simplesamlphp/
+  cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32 > salt.txt
 
   # Front-stage installation.
   # Includes a manual Ruby installation because I can't get DrupalVM to set

--- a/box/doj/vm-setup.sh
+++ b/box/doj/vm-setup.sh
@@ -17,9 +17,10 @@ if [ ! -e "$DRUPAL_BASIC_SETUP_FILE" ]; then
   # Back-stage installation.
   cd /var/www/dojfoia
   composer install
-  cp docroot/sites/default/settings/default.local.settings.php docroot/sites/default/settings/local.settings.php
-  cp -r simplesamlphp/* vendor/simplesamlphp/simplesamlphp/
-  cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32 > salt.txt
+  composer run-script blt-alias
+  source ~/.bash_profile
+  blt setup:settings
+  blt setup:build
 
   # Front-stage installation.
   # Includes a manual Ruby installation because I can't get DrupalVM to set

--- a/box/doj/vm-setup.sh
+++ b/box/doj/vm-setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Create and configure the Drupal files directories.
+DRUPAL_BASIC_SETUP_FILE=/etc/doj_basic_setup_complete
+
+# Check to see if we've already performed this setup.
+if [ ! -e "$DRUPAL_BASIC_SETUP_FILE" ]; then
+
+  # Allow insecure use of wget and curl, because of DOJ network/SSL issues.
+  # TODO: Any way to remove the need for this?
+  echo "check_certificate = off" > /home/vagrant/.wgetrc
+  echo "insecure" > /home/vagrant/.curlrc
+
+  # Clone our repos.
+  cd /var/www
+  sudo chmod 777 .
+  git clone https://github.com/usdoj/foia-api.git
+  git clone https://github.com/usdoj/foia.gov.git
+  # Rename the API repo to match the way it is used in various files: dojfoia.
+  mv foia-api dojfoia
+
+  # Back-stage installation.
+  cd /var/www/dojfoia
+  composer install
+
+  # Front-stage installation.
+  # Includes a manual Ruby installation because I can't get DrupalVM to set
+  # a specific version of Ruby.
+  gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+  \curl -sSL https://get.rvm.io | bash -s stable
+  source /home/vagrant/.rvm/scripts/rvm
+  rvm install "ruby-2.3.4"
+  cd /var/www/foia.gov
+  gem install bundler
+  bundle install
+  npm install
+  NODE_ENV=local APP_ENV=local make build
+
+  # Create a file to indicate this script has already run.
+  sudo touch $DRUPAL_BASIC_SETUP_FILE
+else
+  exit 0
+fi

--- a/box/doj/vm-setup.sh
+++ b/box/doj/vm-setup.sh
@@ -6,11 +6,6 @@ DRUPAL_BASIC_SETUP_FILE=/etc/doj_basic_setup_complete
 # Check to see if we've already performed this setup.
 if [ ! -e "$DRUPAL_BASIC_SETUP_FILE" ]; then
 
-  # Allow insecure use of wget and curl, because of DOJ network/SSL issues.
-  # TODO: Any way to remove the need for this?
-  echo "check_certificate = off" > /home/vagrant/.wgetrc
-  echo "insecure" > /home/vagrant/.curlrc
-
   # Clone our repos.
   cd /var/www
   sudo chmod 777 .

--- a/docroot/sites/default/settings/default.local.settings.php
+++ b/docroot/sites/default/settings/default.local.settings.php
@@ -139,10 +139,3 @@ $settings['trusted_host_patterns'] = array(
  * @see: https://www.drupal.org/node/2837029
  */
 $config['simplesamlphp_auth.settings']['activate'] = false;
-
-/**
- * Set a hash_salt for non-BLT local environments.
- */
-if (empty($settings['hash_salt'])) {
-  $settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
-}

--- a/docroot/sites/default/settings/default.local.settings.php
+++ b/docroot/sites/default/settings/default.local.settings.php
@@ -139,3 +139,10 @@ $settings['trusted_host_patterns'] = array(
  * @see: https://www.drupal.org/node/2837029
  */
 $config['simplesamlphp_auth.settings']['activate'] = false;
+
+/**
+ * Set a hash_salt for non-BLT local environments.
+ */
+if (empty($settings['hash_salt'])) {
+  $settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
+}

--- a/drush/site-aliases/aliases.drushrc.php
+++ b/drush/site-aliases/aliases.drushrc.php
@@ -363,12 +363,12 @@
 // Local environment.
 $aliases['dojfoia.local'] = array(
   'root' => '/var/www/dojfoia/docroot',
-  'uri' => 'http://local.dojfoia.gov',
+  'uri' => 'http://local-api.foia.doj.gov',
   );
 // Add remote connection options when alias is used outside VM.
 if ('vagrant' != $_SERVER['USER']) {
   $aliases['dojfoia.local'] += array(
-    'remote-host' => 'local.dojfoia.gov',
+    'remote-host' => 'local-api.foia.doj.gov',
     'remote-user' => 'vagrant',
     'ssh-options' => '-o PasswordAuthentication=no -i ' . drush_server_home() . '/.vagrant.d/insecure_private_key'
   );

--- a/tests/phpunit/phpunit.xml
+++ b/tests/phpunit/phpunit.xml
@@ -24,7 +24,7 @@
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
-    <env name="SIMPLETEST_BASE_URL" value="http://local.dojfoia.gov"/>
+    <env name="SIMPLETEST_BASE_URL" value="http://local-api.foia.doj.gov"/>
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@localhost/drupal"/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->


### PR DESCRIPTION
These are some initial steps towards a local development box that will work in the locked-down DOJ network/laptops.

Important note: This changes the domain of the BLT box, including the Drush alias, so existing VMs may need to be re-provisioned or re-built.