### PR TITLE
Wrap email submission values in markup

### DIFF
--- a/docroot/modules/custom/foia_webform/src/Plugin/WebformHandler/FoiaEmailWebformHandler.php
+++ b/docroot/modules/custom/foia_webform/src/Plugin/WebformHandler/FoiaEmailWebformHandler.php
@@ -212,7 +212,7 @@ class FoiaEmailWebformHandler extends EmailWebformHandler {
   }
 
   /**
-   * Formats the webform submission contents as a human-readable list.
+   * Formats the webform submission contents as a vertical list.
    *
    * @param array $submissionContents
    *   The webform submission contents.
@@ -221,12 +221,21 @@ class FoiaEmailWebformHandler extends EmailWebformHandler {
    *   Returns the submission contents as a human-readable list.
    */
   protected function formatSubmissionContentsAsList(array $submissionContents) {
-    $list = t('The following list contains the entire submission, and is formatted for ease of viewing and printing.');
-    $list .= '<br /><br />';
+
+    $table = [
+      '#markup' => t('The following list contains the entire submission, and is formatted for ease of viewing and printing.'),
+    ];
+    $rows = [];
     foreach ($submissionContents as $key => $value) {
-      $list .= "<strong>$key</strong>: <p>$value</p>";
+      $rows[] = ["<strong>$key</strong>", $value];
     }
-    return $list;
+    $table['values'] = [
+      '#theme' => 'table',
+      '#rows' => $rows,
+      '#attributes' => ['width' => '500'],
+    ];
+
+    return \Drupal::service('renderer')->renderPlain($table);
   }
 
   /**

--- a/docroot/modules/custom/foia_webform/src/Plugin/WebformHandler/FoiaEmailWebformHandler.php
+++ b/docroot/modules/custom/foia_webform/src/Plugin/WebformHandler/FoiaEmailWebformHandler.php
@@ -227,7 +227,10 @@ class FoiaEmailWebformHandler extends EmailWebformHandler {
     ];
     $rows = [];
     foreach ($submissionContents as $key => $value) {
-      $rows[] = ["<strong>$key</strong>", $value];
+      $rows[] = [
+        ['data' => "<strong>$key</strong>"],
+        ['data' => $value],
+      ];
     }
     $table['values'] = [
       '#theme' => 'table',

--- a/docroot/modules/custom/foia_webform/src/Plugin/WebformHandler/FoiaEmailWebformHandler.php
+++ b/docroot/modules/custom/foia_webform/src/Plugin/WebformHandler/FoiaEmailWebformHandler.php
@@ -84,8 +84,8 @@ class FoiaEmailWebformHandler extends EmailWebformHandler {
     $bodySections = [
       t('Hello,'),
       t('A new FOIA request was submitted to your agency component:'),
-      $this->formatSubmissionContentsAsTable($submissionContents),
       $this->formatSubmissionContentsAsList($submissionContents),
+      $this->formatSubmissionContentsAsTable($submissionContents),
     ];
     $message['body'] = implode('<br /><br />', $bodySections);
 

--- a/docroot/modules/custom/foia_webform/src/Plugin/WebformHandler/FoiaEmailWebformHandler.php
+++ b/docroot/modules/custom/foia_webform/src/Plugin/WebformHandler/FoiaEmailWebformHandler.php
@@ -224,7 +224,7 @@ class FoiaEmailWebformHandler extends EmailWebformHandler {
     $list = t('The following list contains the entire submission, and is formatted for ease of viewing and printing.');
     $list .= '<br /><br />';
     foreach ($submissionContents as $key => $value) {
-      $list .= "<strong>$key</strong>: $value<br />";
+      $list .= "<strong>$key</strong>: <p>$value</p>";
     }
     return $list;
   }

--- a/docroot/modules/custom/foia_webform/src/Plugin/WebformHandler/FoiaEmailWebformHandler.php
+++ b/docroot/modules/custom/foia_webform/src/Plugin/WebformHandler/FoiaEmailWebformHandler.php
@@ -228,7 +228,7 @@ class FoiaEmailWebformHandler extends EmailWebformHandler {
     $rows = [];
     foreach ($submissionContents as $key => $value) {
       $rows[] = [
-        ['data' => "<strong>$key</strong>"],
+        ['data' => ['#markup' => "<strong>$key</strong>"]],
         ['data' => $value],
       ];
     }


### PR DESCRIPTION
This is intended to avoid truncating submission values in the email, when viewing/printing.