### PR TITLE
FOIA-000: Correcting use of bundle as an attribute...

### DIFF
--- a/docroot/modules/custom/webform_template/webform_template.module
+++ b/docroot/modules/custom/webform_template/webform_template.module
@@ -21,7 +21,8 @@ function webform_template_webform_insert(WebformInterface $webform) {
  * Implements hook_entity_presave().
  */
 function webform_template_entity_presave(EntityInterface $entity) {
-  if (!isset($entity->bundle) || !$entity->bundle === 'webform') {
+
+  if (!($entity->bundle()) || $entity->bundle() !== 'webform') {
     return;
   }
   if ($entity->isNew() && empty($entity->getElementsDecoded())) {


### PR DESCRIPTION
... and imprecise if condition.

The original line appeared to filter out any entity without a bundle and any non-webform entity, but in practice let through entities which were not of the webform type. 

` if (!isset($entity->bundle) || !$entity->bundle === 'webform') {`