### PR TITLE
WS-505: Fixed arguments in call to event dispatcher.

### DIFF
--- a/docroot/modules/custom/foia_upload_xml/src/EventSubscriber/FoiaUploadXmlMigrationPostImportSubscriber.php
+++ b/docroot/modules/custom/foia_upload_xml/src/EventSubscriber/FoiaUploadXmlMigrationPostImportSubscriber.php
@@ -114,12 +114,24 @@ class FoiaUploadXmlMigrationPostImportSubscriber implements EventSubscriberInter
 
     try {
       $this->getEventDispatcher()
-        ->dispatch(MigrateEvents::PRE_ROW_SAVE, new MigratePreRowSaveEvent($migration, new MigrateMessage(), $row));
+        ->dispatch(
+          new MigratePreRowSaveEvent(
+            $migration,
+            new MigrateMessage(),
+            $row),
+        MigrateEvents::PRE_ROW_SAVE
+        );
       $destination_ids = $id_map->lookupDestinationIds($row->getSourceIdValues());
       $destination_id_values = $destination_ids ? reset($destination_ids) : [];
       $destination_id_values = $destination->import($row, $destination_id_values);
       $this->getEventDispatcher()
-        ->dispatch(MigrateEvents::POST_ROW_SAVE, new MigratePostRowSaveEvent($migration, new MigrateMessage(), $row, $destination_id_values));
+        ->dispatch(
+        new MigratePostRowSaveEvent($migration,
+          new MigrateMessage(),
+          $row,
+          $destination_id_values),
+        MigrateEvents::POST_ROW_SAVE,
+        );
       $destination_id_values = $destination_id_values ?: [];
       $this->setPartialNodeModerationState($destination_id_values);
       $rollback_action = !empty($destination_id_values) ? $destination->rollbackAction() : NULL;


### PR DESCRIPTION
It looks like this is allowing the XML upload and then the migrations to proceed.  I'm not sure how XML uploads of annual reports were working prior to this fix, however.  Will need more testing on dev, on my local the full report did not completely process, but that might be due to solr not being setup on my cloudIDE.